### PR TITLE
chore(dependency): use changed vector binaries folder

### DIFF
--- a/src/sqlite_rag/database.py
+++ b/src/sqlite_rag/database.py
@@ -29,7 +29,7 @@ class Database:
                 )
             )
             conn.load_extension(
-                str(importlib.resources.files("sqlite-vector.binaries") / "vector")
+                str(importlib.resources.files("sqlite_vector.binaries") / "vector")
             )
         except sqlite3.OperationalError as e:
             raise RuntimeError(


### PR DESCRIPTION
In sqliteai-vector>=0.9.26 the binaries folder is `sqlite_vector`